### PR TITLE
update nova to 3.6.4

### DIFF
--- a/Dockerfile.update-conf
+++ b/Dockerfile.update-conf
@@ -1,4 +1,4 @@
-FROM quay.io/fairwinds/nova:v3.6.2
+FROM quay.io/fairwinds/nova:3.6.4
 
 USER root
 


### PR DESCRIPTION
version 3.6.2 is currently broken because of artifacthub API changes:
```
F0711 13:52:31.063705      61 root.go:272] Error getting artifacthub package repos: failed to search for packages for term cert-manager
```